### PR TITLE
Correctly normalize parameters for oAuth authentication

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,18 @@
 language: php
 
-php:
-    - 5.3
-    - 5.4
-    - 5.5
-    - 5.6
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+matrix:
+  include:
+    - php: 5.3
+      dist: precise
+    - php: 5.4
+    - php: 5.5
+    - php: 5.6
 
 before_script:
-  - composer self-update
-  - composer install --dev --prefer-source
+  - composer install
 
 phpunit: phpunit --coverage-text

--- a/EventListener/OAuthRequestListener.php
+++ b/EventListener/OAuthRequestListener.php
@@ -46,7 +46,7 @@ class OAuthRequestListener
      */
     protected function filterRequestParameters(Request $request)
     {
-        return array_merge(
+        return array_replace(
             $this->parseAuthorizationHeader($request),
             $request->query->all(),
             $request->request->all()

--- a/Service/OAuthAbstractServerService.php
+++ b/Service/OAuthAbstractServerService.php
@@ -308,7 +308,7 @@ abstract class OAuthAbstractServerService implements OAuthServerServiceInterface
 
         $normalizedParameters = array();
         foreach ($requestParameters as $key => $value) {
-            if ('oauth_signature' === $key) {
+            if ('oauth_signature' === $key || empty($value)) {
                 continue;
             }
 
@@ -324,6 +324,7 @@ abstract class OAuthAbstractServerService implements OAuthServerServiceInterface
             }
         }
 
+        $normalizedParameters = array_filter($normalizedParameters);
         sort($normalizedParameters, SORT_STRING);
 
         return implode('&', $normalizedParameters);

--- a/Service/OAuthAbstractServerService.php
+++ b/Service/OAuthAbstractServerService.php
@@ -293,34 +293,38 @@ abstract class OAuthAbstractServerService implements OAuthServerServiceInterface
 
     /**
      * Normalize request parameters.
+     *
      * @see http://oauth.net/core/1.O/#rfc.section.9.1.1
      *
-     * @param  array  $requestParameters An array of request parameters to normalize.
+     * @param  array $requestParameters An array of request parameters to normalize.
+     * @param string $parentKey
      * @return string
      */
-    protected function normalizeRequestParameters($requestParameters)
+    protected function normalizeRequestParameters($requestParameters, $parentKey = '')
     {
-        if (null === $requestParameters) {
+        if (empty($requestParameters)) {
             return '';
         }
 
-        ksort($requestParameters);
-
         $normalizedParameters = array();
         foreach ($requestParameters as $key => $value) {
-            if ('oauth_signature' !== $key) {
-                if (is_array($value)) {
-                    $sortedValues = $value;
+            if ('oauth_signature' === $key) {
+                continue;
+            }
 
-                    sort($sortedValues);
-                    foreach ($sortedValues as $sortedValue) {
-                        $normalizedParameters[] = rawurlencode($key) . '=' . rawurlencode($sortedValue);
-                    }
-                } else {
-                    $normalizedParameters[] = rawurlencode($key) . '=' . rawurlencode($value);
-                }
+            if (!empty($parentKey)) {
+                // Multidimensional array; using foo=bar&foo=baz rather than foo[bar]=baz&foo[baz]=bar
+                $key = $parentKey;
+            }
+
+            if (is_array($value)) {
+                $normalizedParameters[] = $this->normalizeRequestParameters($value, $key);
+            } else {
+                $normalizedParameters[] = rawurlencode($key) . '=' . rawurlencode($value);
             }
         }
+
+        sort($normalizedParameters, SORT_STRING);
 
         return implode('&', $normalizedParameters);
     }

--- a/Service/OAuthAbstractServerService.php
+++ b/Service/OAuthAbstractServerService.php
@@ -312,7 +312,7 @@ abstract class OAuthAbstractServerService implements OAuthServerServiceInterface
                 continue;
             }
 
-            if (!empty($parentKey)) {
+            if ($parentKey !== '') {
                 // Multidimensional array; using foo=bar&foo=baz rather than foo[bar]=baz&foo[baz]=bar
                 $key = $parentKey;
             }

--- a/Tests/Service/OAuthAbstractServerServiceTest.php
+++ b/Tests/Service/OAuthAbstractServerServiceTest.php
@@ -170,9 +170,9 @@ class ConcreteOauthServerService extends OAuthAbstractServerService
         return parent::checkVersion($oauthVersion);
     }
 
-    public function normalizeRequestParameters($requestParameters)
+    public function normalizeRequestParameters($requestParameters, $parentKey = '')
     {
-        return parent::normalizeRequestParameters($requestParameters);
+        return parent::normalizeRequestParameters($requestParameters, $parentKey);
     }
 
     public function approveSignature(ConsumerInterface $consumer, TokenInterface $token = null, $requestParameters, $requestMethod, $requestUrl)

--- a/Tests/Service/OAuthAbstractServerServiceTest.php
+++ b/Tests/Service/OAuthAbstractServerServiceTest.php
@@ -140,6 +140,30 @@ class OAuthAbstractServerServiceTest extends TestCase
         $this->assertEquals('a=bar&b=email%3Atest&c=example%40example.com', $result, 'Test basic encoded params normalization');
     }
 
+    public function testNormalizeRequestParametersWithNestedArray()
+    {
+        $array = array(
+            'b' => array(
+                array(
+                    'b' => 'foo',
+                    'd' => 'bar',
+                    'a' => 'baz',
+                )
+            ),
+            'z' => array(
+                array(
+                    'b' => 'foo',
+                    'd' => 'bar',
+                    'a' => 'baz',
+                )
+            ),
+            'a' => 'bar',
+        );
+
+        $result = $this->service->normalizeRequestParameters($array);
+        $this->assertEquals('a=bar&b=bar&b=baz&b=foo&z=bar&z=baz&z=foo', $result, 'Nested arrays have to be sorted and their values too');
+    }
+
     public function testSendToken()
     {
         $token  = $this->getTokenMock('my_token', 'MySup3rSecr3t', null);


### PR DESCRIPTION
Currently oAuth authenfication for nested arrays is broken as those
information is not decoded like the clients encode the information.
Nested array handling is not covered at all.
This patch simplifies the normalization handling and processes
nested arrays in a proper way. Unfortunately oAuth documentation
fails to give some expectations on how to normalize nested array
information correctly, so each dimension is sorted on its own.