### PR TITLE
update Token field to address Mautic doctrine:schema:validate

### DIFF
--- a/Model/Token.php
+++ b/Model/Token.php
@@ -22,7 +22,7 @@ abstract class Token implements TokenInterface
     protected $secret;
 
     /**
-     * @var int
+     * @var integer
      */
     protected $expiresAt;
 

--- a/Model/TokenInterface.php
+++ b/Model/TokenInterface.php
@@ -39,13 +39,13 @@ interface TokenInterface
 
     /**
      * Returns the expiration time.
-     * @return int
+     * @return integer
      */
     public function getExpiresAt();
 
     /**
      * Set expiresAt
-     * @param int $expiresAt
+     * @param integer $expiresAt
      * @return self
      */
     public function setExpiresAt($expiresAt);

--- a/Resources/config/model/AccessToken.orm.xml
+++ b/Resources/config/model/AccessToken.orm.xml
@@ -10,7 +10,7 @@
 
         <field name="secret" column="secret" type="string" />
 
-        <field name="expiresAt" column="expiresAt" type="int" />
+        <field name="expiresAt" column="expiresAt" type="integer" />
 
     </mapped-superclass>
 

--- a/Resources/config/model/RequestToken.orm.xml
+++ b/Resources/config/model/RequestToken.orm.xml
@@ -10,7 +10,7 @@
 
         <field name="secret" column="secret" type="string" />
 
-        <field name="expiresAt" column="expiresAt" type="int" />
+        <field name="expiresAt" column="expiresAt" type="integer" />
 
         <field name="verifier" column="verifier" type="string" />
 


### PR DESCRIPTION
## `int` => `integer`

- :rotating_light: update Token field type in orm model
- :rotating_light: update type hinting in Model/Token

```log
[Mapping] FAIL - The entity-class 'Bazinga\OAuthServerBundle\Model\AccessToken' mapping is invalid:
The field 'Bazinga\OAuthServerBundle\Model\AccessToken#expiresAt' uses a non-existant type 'int'.

[Mapping] FAIL - The entity-class 'Bazinga\OAuthServerBundle\Model\RequestToken' mapping is invalid:
The field 'Bazinga\OAuthServerBundle\Model\RequestToken#expiresAt' uses a non-existant type 'int'.
```

Closes [mautic/mautic #5848](/mautic/mautic/issues/5848)